### PR TITLE
When doing checkpoint, write cache data to doris to prevent loss

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/cfg/GenericDorisSinkFunction.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/cfg/GenericDorisSinkFunction.java
@@ -53,12 +53,12 @@ public class GenericDorisSinkFunction<T> extends RichSinkFunction<T>
 
     @Override
     public void initializeState(FunctionInitializationContext context) throws Exception {
-        outputFormat.flush();
+       
     }
 
     @Override
     public void snapshotState(FunctionSnapshotContext context) throws Exception {
-
+          outputFormat.flush();
     }
 
     @Override

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/cfg/GenericDorisSinkFunction.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/cfg/GenericDorisSinkFunction.java
@@ -53,7 +53,7 @@ public class GenericDorisSinkFunction<T> extends RichSinkFunction<T>
 
     @Override
     public void initializeState(FunctionInitializationContext context) throws Exception {
-
+        outputFormat.flush();
     }
 
     @Override

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/table/DorisDynamicTableSink.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/table/DorisDynamicTableSink.java
@@ -24,6 +24,7 @@ import org.apache.flink.table.connector.ChangelogMode;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
 import org.apache.flink.table.connector.sink.OutputFormatProvider;
 import org.apache.flink.types.RowKind;
+import org.apache.doris.flink.cfg.GenericDorisSinkFunction;
 
 /**
  * DorisDynamicTableSink
@@ -65,7 +66,7 @@ public class DorisDynamicTableSink implements DynamicTableSink {
                 .setExecutionOptions(executionOptions)
                 .setFieldDataTypes(tableSchema.getFieldDataTypes())
                 .setFieldNames(tableSchema.getFieldNames());
-        return OutputFormatProvider.of(builder.build());
+        return new GenericDorisSinkFunction(builder.build());
     }
 
     @Override

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/table/DorisDynamicTableSink.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/table/DorisDynamicTableSink.java
@@ -25,6 +25,7 @@ import org.apache.flink.table.connector.sink.DynamicTableSink;
 import org.apache.flink.table.connector.sink.OutputFormatProvider;
 import org.apache.flink.types.RowKind;
 import org.apache.doris.flink.cfg.GenericDorisSinkFunction;
+import org.apache.flink.table.connector.sink.SinkFunctionProvider;
 
 /**
  * DorisDynamicTableSink
@@ -66,7 +67,7 @@ public class DorisDynamicTableSink implements DynamicTableSink {
                 .setExecutionOptions(executionOptions)
                 .setFieldDataTypes(tableSchema.getFieldDataTypes())
                 .setFieldNames(tableSchema.getFieldNames());
-        return new GenericDorisSinkFunction(builder.build());
+        return SinkFunctionProvider.of(new GenericDorisSinkFunction(builder.build()));
     }
 
     @Override


### PR DESCRIPTION
# Proposed changes

Issue Number: close 

## Problem Summary:

Describe the overview of changes.
flink写doris是批量写入，用户设置条数为1000条时，才flush，假如写入500条时，程序正好做checkpoint成功了，kafka的offset做了相应的commit，后面500条过来后，未做checkpoint，但此时doris服务器出了问题，导致flush报错，flink的task重启，重新从上次checkpoint commit的offset消费kafka，导致前面500条数据出现丢失情况
## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (No)
3. Has document been added or modified: (No)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
