### PR TITLE
[feature]Supports traversal of Doris FE nodes when searching for Doris BE

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/rest/RestService.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/rest/RestService.java
@@ -244,6 +244,26 @@ public class RestService implements Serializable {
     }
 
     /**
+     * choice a Doris FE node to request.
+     *
+     * @param feNodes Doris FE node list, separate be comma
+     * @param logger  slf4j logger
+     * @return the array of Doris FE nodes
+     * @throws IllegalArgumentException fe nodes is illegal
+     */
+    @VisibleForTesting
+    static List<String> allEndpoints(String feNodes, Logger logger) throws IllegalArgumentException {
+        logger.trace("Parse fenodes '{}'.", feNodes);
+        if (StringUtils.isEmpty(feNodes)) {
+            logger.error(ILLEGAL_ARGUMENT_MESSAGE, "fenodes", feNodes);
+            throw new IllegalArgumentException("fenodes", feNodes);
+        }
+        List<String> nodes = Arrays.stream(feNodes.split(",")).map(String::trim).collect(Collectors.toList());
+        Collections.shuffle(nodes);
+        return nodes;
+    }
+
+    /**
      * choice a Doris BE node to request.
      *
      * @param options configuration of request
@@ -328,13 +348,22 @@ public class RestService implements Serializable {
     @VisibleForTesting
     static List<BackendV2.BackendRowV2> getBackendsV2(DorisOptions options, DorisReadOptions readOptions, Logger logger) throws DorisException, IOException {
         String feNodes = options.getFenodes();
-        String feNode = randomEndpoint(feNodes, logger);
-        String beUrl = "http://" + feNode + BACKENDS_V2;
-        HttpGet httpGet = new HttpGet(beUrl);
-        String response = send(options, readOptions, httpGet, logger);
-        logger.info("Backend Info:{}", response);
-        List<BackendV2.BackendRowV2> backends = parseBackendV2(response, logger);
-        return backends;
+        List<String> feNodeList = allEndpoints(feNodes, logger);
+        for (String feNode: feNodeList) {
+            try {
+                String beUrl = "http://" + feNode + BACKENDS_V2;
+                HttpGet httpGet = new HttpGet(beUrl);
+                String response = send(options, readOptions, httpGet, logger);
+                logger.info("Backend Info:{}", response);
+                List<BackendV2.BackendRowV2> backends = parseBackendV2(response, logger);
+                return backends;
+            } catch (ConnectedFailedException e) {
+                logger.info("Doris FE node {} is unavailable: {}, Request the next Doris FE node", feNode, e.getMessage());
+            }
+        }
+        String errMsg = "No Doris FE is available, please check configuration";
+        logger.error(errMsg);
+        throw new DorisException(errMsg);
     }
 
     static List<BackendV2.BackendRowV2> parseBackendV2(String response, Logger logger) throws DorisException, IOException {


### PR DESCRIPTION
# Proposed changes


## Problem Summary:
目前，使用 flink-doris-connector 写入 Doris ，当配置了多个 Doris FE 节点的前提下， 内部通过 FE 节点请求到 BE 时会随机选择其中一个 FE 提交 http 请求 BE 节点地址；在生产环境中，由于机器原因或者是版本升级需要滚动重启 FE 服务时，由于某个 FE 服务暂时不可用，可能会引起 flink 作业异常退出；
为了降低集群变更或偶发异常影响实时流稳定，考虑通过对所有配置的  Doris FE 节点发送 http 请求查询 Doris BE。

Currently, when Flink-doris-Connetor writes Doris, it will queries Doris FE node through one of the Doris BE nodes randomly. It may causing job failures when one of Doris BE node in cluster is out of service. For example, sometime  machine has problem and need to restart or admin need to Actively restart service In the process of upgrading the version

## Checklist(Required)

1. Does it affect the original behavior: (Yes)
2. Has unit tests been added: (No Need)
3. Has document been added or modified: (No Need)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments
