### PR TITLE
[improvement] (before 1.13)Support set max bytes in each batch to avoid congestion

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/cfg/DorisExecutionOptions.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/cfg/DorisExecutionOptions.java
@@ -31,10 +31,12 @@ public class DorisExecutionOptions implements Serializable {
     public static final Integer DEFAULT_BATCH_SIZE = 10000;
     public static final Integer DEFAULT_MAX_RETRY_TIMES = 1;
     private static final Long DEFAULT_INTERVAL_MILLIS = 10000L;
+    public static final Long DEFAULT_MAX_BATCH_BYTES = 1024 * 1024 * 10L;
 
     private final Integer batchSize;
     private final Integer maxRetries;
     private final Long batchIntervalMs;
+    private final Long maxBatchBytes;
 
     /**
      * Properties for the StreamLoad.
@@ -44,13 +46,15 @@ public class DorisExecutionOptions implements Serializable {
     private final Boolean enableDelete;
 
 
-    public DorisExecutionOptions(Integer batchSize, Integer maxRetries, Long batchIntervalMs, Properties streamLoadProp, Boolean enableDelete) {
+    public DorisExecutionOptions(Integer batchSize, Integer maxRetries, Long batchIntervalMs, Properties streamLoadProp, Boolean enableDelete, Long maxBatchBytes) {
         Preconditions.checkArgument(maxRetries >= 0);
+        Preconditions.checkArgument(maxBatchBytes >= 0);
         this.batchSize = batchSize;
         this.maxRetries = maxRetries;
         this.batchIntervalMs = batchIntervalMs;
         this.streamLoadProp = streamLoadProp;
         this.enableDelete = enableDelete;
+        this.maxBatchBytes = maxBatchBytes;
     }
 
     public static Builder builder() {
@@ -84,6 +88,10 @@ public class DorisExecutionOptions implements Serializable {
         return enableDelete;
     }
 
+    public Long getMaxBatchBytes() {
+        return maxBatchBytes;
+    }
+
     /**
      * Builder of {@link DorisExecutionOptions}.
      */
@@ -93,6 +101,7 @@ public class DorisExecutionOptions implements Serializable {
         private Long batchIntervalMs = DEFAULT_INTERVAL_MILLIS;
         private Properties streamLoadProp = new Properties();
         private Boolean enableDelete = false;
+        private Long maxBatchBytes = DEFAULT_MAX_BATCH_BYTES;
 
         public Builder setBatchSize(Integer batchSize) {
             this.batchSize = batchSize;
@@ -119,8 +128,13 @@ public class DorisExecutionOptions implements Serializable {
             return this;
         }
 
+        public Builder setMaxBatchBytes(Long maxBatchBytes) {
+            this.maxBatchBytes = maxBatchBytes;
+            return this;
+        }
+
         public DorisExecutionOptions build() {
-            return new DorisExecutionOptions(batchSize, maxRetries, batchIntervalMs, streamLoadProp, enableDelete);
+            return new DorisExecutionOptions(batchSize, maxRetries, batchIntervalMs, streamLoadProp, enableDelete, maxBatchBytes);
         }
     }
 

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/table/DorisDynamicOutputFormat.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/table/DorisDynamicOutputFormat.java
@@ -30,7 +30,7 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.types.RowKind;
-import org.apache.flink.util.concurrent.ExecutorThreadFactory;
+import org.apache.flink.runtime.util.ExecutorThreadFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/table/DorisDynamicTableFactory.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/table/DorisDynamicTableFactory.java
@@ -141,6 +141,12 @@ public final class DorisDynamicTableFactory implements DynamicTableSourceFactory
             .booleanType()
             .defaultValue(true)
             .withDescription("whether to enable the delete function");
+    private static final ConfigOption<Long> SINK_BUFFER_FLUSH_MAX_BYTES = ConfigOptions
+            .key("sink.batch.bytes")
+            .longType()
+            .defaultValue(DorisExecutionOptions.DEFAULT_MAX_BATCH_BYTES)
+            .withDescription("the flush max bytes (includes all append, upsert and delete records), over this number" +
+                    " in batch, will flush data. The default value is 10MB.");
 
     @Override
     public String factoryIdentifier() {
@@ -179,6 +185,7 @@ public final class DorisDynamicTableFactory implements DynamicTableSourceFactory
         options.add(SINK_MAX_RETRIES);
         options.add(SINK_BUFFER_FLUSH_INTERVAL);
         options.add(SINK_ENABLE_DELETE);
+        options.add(SINK_BUFFER_FLUSH_MAX_BYTES);
         return options;
     }
 
@@ -235,6 +242,7 @@ public final class DorisDynamicTableFactory implements DynamicTableSourceFactory
         builder.setBatchIntervalMs(readableConfig.get(SINK_BUFFER_FLUSH_INTERVAL).toMillis());
         builder.setStreamLoadProp(streamLoadProp);
         builder.setEnableDelete(readableConfig.get(SINK_ENABLE_DELETE));
+        builder.setMaxBatchBytes(readableConfig.get(SINK_BUFFER_FLUSH_MAX_BYTES));
         return builder.build();
     }
 

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/DorisSourceSinkExample.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/DorisSourceSinkExample.java
@@ -56,6 +56,7 @@ public class DorisSourceSinkExample {
                         "  'username' = 'root',\n" +
                         "  'password' = '',\n" +
                         "  'sink.batch.size' = '3',\n" +
+                        "  'sink.batch.bytes' = '1',\n" +
                         "  'sink.max-retries' = '2'\n" +
                         ")");
 


### PR DESCRIPTION
## Problem Summary:
目前，dorisSink 刷入 batch 的时机依赖 "batchSize" 和 "batchIntervalMs"，一般情形下是能够符合预期的；但是当数据源流量或者单条消息数据量极大时，可能会造成单个 batch 的数据很大，进而会导致数据刷入 doris 时长时间阻塞影响实时性能，甚至请求 BE 超时无法正常写入的问题。

出于上述原因，提供依据 "maxBatchBytes" 刷 batch 到 doris 中，修改点：
* 类 `DorisExecutionOptions`: 增加一个可配置选项 `maxBatchBytes`
* 类 `DorisDynamicOutputFormat`: 估计当前 batch 的数据量 `batchBytes` 达到阈值 `maxBatchBytes` 时，刷入 doris。

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (No Need)
3. Has document been added or modified: (No Need)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments
