### PR TITLE
json load by line

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/DorisSink.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/DorisSink.java
@@ -126,10 +126,12 @@ public class DorisSink<IN> implements Sink<IN, DorisCommittable, DorisWriterStat
 
         public DorisSink<IN> build() {
             Preconditions.checkNotNull(dorisOptions);
-            Preconditions.checkNotNull(dorisReadOptions);
             Preconditions.checkNotNull(dorisExecutionOptions);
             Preconditions.checkNotNull(serializer);
             EscapeHandler.handleEscape(dorisExecutionOptions.getStreamLoadProp());
+            if(dorisReadOptions == null) {
+                dorisReadOptions = DorisReadOptions.builder().build();
+            }
             return new DorisSink<>(dorisOptions, dorisReadOptions, dorisExecutionOptions, serializer);
         }
     }

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/table/DorisDynamicTableSink.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/table/DorisDynamicTableSink.java
@@ -77,8 +77,7 @@ public class DorisDynamicTableSink implements DynamicTableSink {
     @Override
     public SinkRuntimeProvider getSinkRuntimeProvider(Context context) {
         Properties loadProperties = executionOptions.getStreamLoadProp();
-        boolean deletable = RestService.isUniqueKeyType(options, readOptions, LOG) && executionOptions.getDeletable();
-
+        boolean deletable = RestService.isUniqueKeyType(options, readOptions, LOG) || executionOptions.getDeletable();
         if (!loadProperties.containsKey(COLUMNS_KEY)) {
             String[] fieldNames = tableSchema.getFieldNames();
             Preconditions.checkState(fieldNames != null && fieldNames.length > 0);

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/DorisSinkExample.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/DorisSinkExample.java
@@ -21,6 +21,7 @@ import org.apache.doris.flink.cfg.DorisOptions;
 import org.apache.doris.flink.cfg.DorisReadOptions;
 import org.apache.doris.flink.sink.DorisSink;
 import org.apache.doris.flink.sink.writer.SimpleStringSerializer;
+import org.apache.flink.api.common.RuntimeExecutionMode;
 import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.api.common.time.Time;
@@ -40,6 +41,7 @@ public class DorisSinkExample {
     public static void main(String[] args) throws Exception{
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+        env.setRuntimeMode(RuntimeExecutionMode.BATCH);
         env.enableCheckpointing(10000);
         env.getCheckpointConfig().enableExternalizedCheckpoints(CheckpointConfig.ExternalizedCheckpointCleanup.RETAIN_ON_CANCELLATION);
         env.setRestartStrategy(RestartStrategies.fixedDelayRestart(5, Time.milliseconds(30000)));

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/DorisSinkSQLExample.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/DorisSinkSQLExample.java
@@ -16,6 +16,7 @@
 // under the License.
 package org.apache.doris.flink;
 
+import org.apache.flink.api.common.RuntimeExecutionMode;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.streaming.api.datastream.DataStreamSource;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -31,6 +32,7 @@ public class DorisSinkSQLExample {
     public static void main(String[] args) {
         final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         env.setParallelism(1);
+        env.setRuntimeMode(RuntimeExecutionMode.BATCH);
         final StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);
 
         List<Tuple2<String, Integer>> data = new ArrayList<>();
@@ -53,7 +55,7 @@ public class DorisSinkSQLExample {
                         "  'sink.buffer-count' = '4',\n" +
                         "  'sink.buffer-size' = '4086'," +
                         "  'sink.label-prefix' = 'doris_label',\n" +
-                        "  'sink.properties.strip_outer_array' = 'true'\n" +
+                        "  'sink.properties.read_json_by_line' = 'true'\n" +
                         ")");
         tEnv.executeSql("INSERT INTO doris_test_sink select name,age from doris_test");
     }

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/DorisSourceSinkExample.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/DorisSourceSinkExample.java
@@ -55,8 +55,8 @@ public class DorisSourceSinkExample {
                         "  'table.identifier' = 'db.table',\n" +
                         "  'username' = 'root',\n" +
                         "  'password' = '',\n" +
-                        "  'sink.batch.size' = '3',\n" +
-                        "  'sink.max-retries' = '2'\n" +
+                        "  'sink.properties.format' = 'csv',\n" +
+                        "  'sink.label-prefix' = 'doris_csv_table'\n" +
                         ")");
 
         tEnv.executeSql("INSERT INTO doris_test_sink select name,age,price,sale from doris_test");

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/writer/TestDorisStreamLoad.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/writer/TestDorisStreamLoad.java
@@ -106,7 +106,7 @@ public class TestDorisStreamLoad {
         properties.setProperty("line_delimiter", "\n");
         properties.setProperty("format", "json");
         executionOptions = OptionUtils.buildExecutionOptional(properties);
-        byte[] expectBuffer = "[{\"id\": 1},{\"id\": 2}]".getBytes(StandardCharsets.UTF_8);
+        byte[] expectBuffer = "{\"id\": 1}\n{\"id\": 2}".getBytes(StandardCharsets.UTF_8);
         CloseableHttpClient httpClient = mock(CloseableHttpClient.class);
         CloseableHttpResponse preCommitResponse = HttpTestUtil.getResponse(HttpTestUtil.PRE_COMMIT_RESPONSE, true);
         when(httpClient.execute(any())).thenReturn(preCommitResponse);


### PR DESCRIPTION
# Proposed changes

1. For stream load with json format，support read_json_by_line instead of strip_outer_array
2.  Remove non empty check for dorisReadOptions

## Checklist(Required)

1. Does it affect the original behavior: (No)
4. Has unit tests been added: (Yes)
5. Has document been added or modified: (No Need)
6. Does it need to update dependencies: (No)
7. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
