### PR TITLE
[Bug] fix flink schema and doris schema column not match

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/cfg/DorisReadOptions.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/cfg/DorisReadOptions.java
@@ -98,6 +98,13 @@ public class DorisReadOptions implements Serializable {
         return deserializeArrowAsync;
     }
 
+    public void setReadFields(String readFields) {
+        this.readFields = readFields;
+    }
+
+    public void setFilterQuery(String filterQuery) {
+        this.filterQuery = filterQuery;
+    }
 
     public static Builder builder() {
         return new Builder();

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/table/DorisDynamicTableSource.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/table/DorisDynamicTableSource.java
@@ -38,7 +38,9 @@ import org.apache.flink.table.types.logical.RowType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * The {@link DorisDynamicTableSource} is used during planning.
@@ -70,8 +72,13 @@ public final class DorisDynamicTableSource implements ScanTableSource, LookupTab
 
     @Override
     public ScanRuntimeProvider getScanRuntimeProvider(ScanContext runtimeProviderContext) {
+        readOptions.setReadFields(Arrays.stream(physicalSchema.getFieldNames())
+                .map(item->String.format("`%s`", item.trim().replace("`", "")))
+                .collect(Collectors.joining(", ")));
+
         List<PartitionDefinition> dorisPartitions;
         try {
+            //request doris query plan
             dorisPartitions = RestService.findPartitions(options, readOptions, LOG);
         } catch (DorisException e) {
             throw new RuntimeException("Failed fetch doris partitions");

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/table/DorisRowDataInputFormat.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/table/DorisRowDataInputFormat.java
@@ -158,6 +158,9 @@ public class DorisRowDataInputFormat extends RichInputFormat<RowData, DorisTable
     }
 
     private Object deserialize(LogicalType type, Object val) {
+        if(val == null){
+            return null;
+        }
         switch (type.getTypeRoot()) {
             case DECIMAL:
                 final DecimalType decimalType = ((DecimalType) type);

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/DorisSourceExample.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/DorisSourceExample.java
@@ -50,6 +50,7 @@ public class DorisSourceExample {
                         "  'connector' = 'doris',\n" +
                         "  'fenodes' = 'FE_IP:8030',\n" +
                         "  'table.identifier' = 'db.table',\n" +
+                        "  'doris.filter.query' = 'bigint_1=1',\n" +
                         "  'username' = 'root',\n" +
                         "  'password' = ''\n" +
                         ")");


### PR DESCRIPTION
# Proposed changes

Issue Number: close #28 

## Problem Summary:

1.When the number of schemas of flink is inconsistent with the number of doris schemas, an error will be reported, especially when there are hidden columns in doris
<img width="543" alt="image" src="https://user-images.githubusercontent.com/7951521/164961180-78a0d7b7-d6e4-4c4b-9e28-6ed41ced26e2.png">
2. deserialize has npe bug

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
