### PR TITLE
[fix] build.sh script  --flink 1.14.3 --scala 2.12parameters do not take effect

### DIFF
--- a/flink-doris-connector/build.sh
+++ b/flink-doris-connector/build.sh
@@ -55,15 +55,6 @@ if [ $# == 0 ] ; then
     usage
 fi
 
-eval set -- "$OPTS"
-
-. "${DORIS_HOME}"/env.sh
-
-# include custom environment variables
-if [[ -f ${DORIS_HOME}/custom_env.sh ]]; then
-    . "${DORIS_HOME}"/custom_env.sh
-fi
-
 BUILD_FROM_TAG=0
 FLINK_VERSION=0
 SCALA_VERSION=0
@@ -73,9 +64,18 @@ while true; do
         --scala) SCALA_VERSION=$2 ; shift 2 ;;
         --tag) BUILD_FROM_TAG=1 ; shift ;;
         --) shift ;  break ;;
-        *) echo "Internal error" ; exit 1 ;;
+        *) break ;;
     esac
 done
+
+eval set -- "$OPTS"
+
+. "${DORIS_HOME}"/env.sh
+
+# include custom environment variables
+if [[ -f ${DORIS_HOME}/custom_env.sh ]]; then
+    . "${DORIS_HOME}"/custom_env.sh
+fi
 
 # extract minor version:
 # eg: 1.14.3 -> 1.14
@@ -90,7 +90,7 @@ if [[ ${BUILD_FROM_TAG} -eq 1 ]]; then
     ${MVN_BIN} clean package
 else
     rm -rf output/
-    ${MVN_BIN} clean package -Dscala.version=${SCALA_VERSION} -Dflink.version=${FLINK_VERSION} -Dflink.minor.version=${FLINK_MINOR_VERSION}
+    ${MVN_BIN} clean package -Dscala.version=${SCALA_VERSION} -Dflink.version=${FLINK_VERSION} -Dflink.minor.version=${FLINK_MINOR_VERSION} -DskipTests
 fi
 
 echo "*****************************************"


### PR DESCRIPTION
## Problem Summary:

1.The flink connector is compiled using the build.sh script, and the --flink 1.14.3 --scala 2.12 parameters do not take effect

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
